### PR TITLE
Added and improved Dutch translation

### DIFF
--- a/app/src/main/assets/en/about.html
+++ b/app/src/main/assets/en/about.html
@@ -15,10 +15,11 @@ Copyright © 2012-2016 Arno Welzel</h2>
 <p>French &ndash; Sébastien Gravier<br />
 Italian &ndash; Valerio Bozzolan<br />
 Russian &ndash; Wjatscheslaw Stoljarski<br />
+Dutch &ndash; Pander<br />
 Spanish &ndash; Laura Arjona Reina</p>
 
 <p>This program is free software: you can redistribute it and/or modify it under the terms of the
-GNU General Public License as published by the Free Software Foundation, either version 3 of the License,
+GNU General Public License as published by the Free Software Foundation, either version 3 of this license,
 or (at your option) any later version.</p>
 
 <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied

--- a/app/src/main/assets/nl/about.html
+++ b/app/src/main/assets/nl/about.html
@@ -1,31 +1,31 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="nl-NL">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<title>About</title>
+<title>Over</title>
 </head>
 <body>
 <h1>Periodical 0.24</h1>
 
-<h2>Calculation of fertility according to Knaus&#8211;Ogino<br />
+<h2>Berekening van vruchtbaarheid volgens Knaus&#8211;Ogino<br />
 Copyright © 2012-2016 Arno Welzel</h2>
 
-<p>Translation:</p>
+<p>Vertaling:</p>
 
-<p>French &ndash; Sébastien Gravier<br />
-Italian &ndash; Valerio Bozzolan<br />
-Russian &ndash; Wjatscheslaw Stoljarski<br />
-Spanish &ndash; Laura Arjona Reina</p>
+<p>Frans &ndash; Sébastien Gravier<br />
+Italiaans &ndash; Valerio Bozzolan<br />
+Russisch &ndash; Wjatscheslaw Stoljarski<br />
+Nederlands &ndash; Pander<br />
+Spaans &ndash; Laura Arjona Reina</p>
 
-<p>This program is free software: you can redistribute it and/or modify it under the terms of the
-GNU General Public License as published by the Free Software Foundation, either version 3 of the License,
-or (at your option) any later version.</p>
+<p>Deze applicatie is vrije software: je mag deze herdistribueren en/of aanpassen volgens de voorwaarden van de
+GNU General Public License die door de Free Software Foundation is gepubliceerd, ofwel versie 3 van de licentie,
+of (als eigen keuze) elke latere versie.</p>
 
-<p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-more details.</p>
+<p>Deze applicatie is gedistribueerd in de hoop dat deze nuttig zal zijn, maar ZONDER ENIGE GARANTIE; zelf zonder de implicite garantie van VERKOOPBAARHEID of GESCHIKTHEID VOOR EEN BEPAALD DOEL. Zie de GNU General Public License voor
+meer details.</p>
 
-<p>You should have received a copy of the GNU General Public License along with this program.
-If not, see <a href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses/</a>.</p>
+<p>Je zou een kopie van de GNU General Public License bij deze applicatie moeten ontvangen.
+Is dat niet het geval, zie <a href="http://www.gnu.org/licenses/">http://www.gnu.org/licenses/</a>.</p>
 </body>
 </html>

--- a/app/src/main/assets/nl/help.html
+++ b/app/src/main/assets/nl/help.html
@@ -1,31 +1,37 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="nl-NL">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Help</title>
 </head>
 <body>
-<p><em>WARNING: It is not recommended to use this calendar to avoid pregnancy! There are more accurate methods, like
-measuring the basal body temperature.</em></p>
+<p><em>WAARSCHUWING: Het is niet aanbevolen om deze kalender te gebruiken om
+zwangerschap te voorkomen! Er bestaan meer nauwkeurige methodes, zoals
+het meten van de basale lichaamstemperatuur.</em></p>
 
-<p>You can change the month using the buttons or by swiping to the left or to the right.</p>
+<p>Je kan van maand wisselen door de knoppen te gebruiken of naar links of
+rechts te swipen.</p>
 
-<p>To indicate the first day of the period, just tap the day in the calendar. To remove the entry, tap again.</p>
+<p>Tap op een dat in de kalender om de eerste dag van de menstruatie aan te
+geven. Tap er nog eens op om deze te verwijderen.</p>
 
-<p>Colors indicate the meaning of a day:</p>
+<p>Kleuren representeren de betekenis van een dag:</p>
 
-<p>Red &ndash; Days of the period.</p>
+<p>Rood &ndash; Dagen van menstruatie.</p>
 
-<p>Blue &ndash; Fertile days.</p>
+<p>Blauw &ndash; Vruchtbare dagen.</p>
 
-<p>Yellow &ndash; Infertile days.</p>
+<p>Geel &ndash; Onvruchtbare dagen.</p>
 
-<p>The calculated day of ovulation is marked with an O. The current day is marked with a circle.</p>
+<p>De uitgerekende dat van ovulatie is gemarkeerd met een O. De huidige dag is
+gemarkeerd met een cirkel.</p>
 
-<p>The calculation is done for two cycles in advance.</p>
+<p>De berekening wordt twee cycli vooruit gemaakt.</p>
 
-<p>If you tap on an entry in the list, the corresponding month is displayed in the calendar.</p>
+<p>Als op in de lijst een tap doet wordt de corresponderende maand in de
+kalender getoond.</p>
 
-<p>To use the data backup, a memory card or internal memory must be present.</p>
+<p>Een geheugenkaart of intern geheugen moet beschikbaar zijn voor het maken van
+een backup van de data.</p>
 </body>
 </html>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -40,17 +40,17 @@
     <string name="restore_cancel">Annuleer</string>
     <string name="restore_finished">Herstel is klaar</string>
     <string name="restore_failed">Herstel faalde!</string>
-    <string name="event_periodstart">Periode is begonnen</string>
+    <string name="event_periodstart">Menstruatie is begonnen</string>
     <string name="event_periodlength">Laatste cyclus duurde %s dagen</string>
     <string name="event_periodfirst">Eerste invoer</string>
     <string name="calendaraction_title">Bewerk kalenderinvoer</string>
-    <string name="calendaraction_add">Markeer deze dag als \"Period is begonnen\"?</string>
+    <string name="calendaraction_add">Markeer deze dag als \"Menstruatie is begonnen\"?</string>
     <string name="calendaraction_remove">Verwijder de \"Periode is begonnen\" markering voor deze dag?</string>
     <string name="calendaraction_ok">Ja</string>
     <string name="calendaraction_cancel">Nee</string>
     <string name="options_title">Instellingen</string>
-    <string name="pref_periodlength">Standaardlengte van periode (dagen)</string>
-    <string name="invalid_period_length">De standaardlengte van een periode is tussen 1 en 14!</string>
+    <string name="pref_periodlength">Standaardduur van menstruatie (dagen)</string>
+    <string name="invalid_period_length">De standaardduur van een menstruatie is tussen 1 en 14!</string>
     <string name="pref_startofweek">Begin van de week</string>
     <string-array name="list_startofweek">
         <item>Zondag</item>
@@ -68,9 +68,9 @@
     <string name="label_day">Dag</string>
     <string name="label_infertile">onvruchtbaar</string>
     <string name="label_fertile">vruchtbaar</string>
-    <string name="label_period_started">periode is begonnen</string>
-    <string name="label_period">periode</string>
-    <string name="label_period_predicted">periode voorspeld</string>
+    <string name="label_period_started">menstruatie is begonnen</string>
+    <string name="label_period">menstruatie</string>
+    <string name="label_period_predicted">menstruatie voorspeld</string>
     <string name="label_ovulation">ovulatie</string>
     <string name="asset_about">nl/about.html</string>
     <string name="asset_help">nl/help.html</string>


### PR DESCRIPTION
Here is complete Dutch translation. Please double check if period is translated in the right places as _menstruatie_. Somewhere in the values.xml file, period is used in label_average_period, label_shortest_period and label_longest_period but I think that should be cyclus. If this is true, please refactor the name of the key. Let me know anyway, what was intended there.