### PR TITLE
Allow user to specify luteal phase

### DIFF
--- a/app/src/main/java/de/arnowelzel/android/periodical/OptionsActivity.java
+++ b/app/src/main/java/de/arnowelzel/android/periodical/OptionsActivity.java
@@ -67,7 +67,31 @@ public class OptionsActivity extends PreferenceActivity implements SharedPrefere
                     return true;
                 }
             });
-        
+
+        // Add validation for luteal length
+        findPreference("luteal_length").setOnPreferenceChangeListener(
+            new Preference.OnPreferenceChangeListener() {
+
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    int value;
+                    try {
+                        value = Integer.parseInt(newValue.toString());
+                    } catch (NumberFormatException e) {
+                        value = 0;
+                    }
+
+                    if (value < 1) {
+                        Toast.makeText(context,
+                                getResources().getString(R.string.invalid_luteal_length),
+                                Toast.LENGTH_SHORT).show();
+                        return false;
+                    }
+
+                    return true;
+                }
+            });
+
         // Activate "back button" in Action Bar if possible
         if (android.os.Build.VERSION.SDK_INT >= 11) {
             ActionBar actionBar = getActionBar();

--- a/app/src/main/java/de/arnowelzel/android/periodical/PeriodicalDatabase.java
+++ b/app/src/main/java/de/arnowelzel/android/periodical/PeriodicalDatabase.java
@@ -288,6 +288,7 @@ public class PeriodicalDatabase {
         int ovulationday = 0;
         Cursor result;
         int periodlength;
+        int luteallength;
         int dayofcycle;
 
         // Get default values from preferences
@@ -296,6 +297,11 @@ public class PeriodicalDatabase {
             periodlength = Integer.parseInt(preferences.getString("period_length", "4"));
         } catch (NumberFormatException e) {
             periodlength = 4;
+        }
+        try {
+            luteallength = Integer.parseInt(preferences.getString("luteal_length", "14"));
+        } catch (NumberFormatException e) {
+            luteallength = 14;
         }
 
         // Clean up existing data
@@ -361,7 +367,7 @@ public class PeriodicalDatabase {
                 // Calculate a predicted ovulation date
                 int average = this.cycleAverage;
                 if (count > 0) average /= count;
-                ovulationday = average - 14;
+                ovulationday = average - luteallength;
 
                 // Calculate days from the last event until now
                 GregorianCalendar datePrevious = new GregorianCalendar();
@@ -379,8 +385,8 @@ public class PeriodicalDatabase {
                     } else if (day == ovulationday) {
                         // Day of ovulation
                         type = DayEntry.OVULATION_PREDICTED;
-                    } else if (day >= this.cycleShortest - 18
-                            && day <= this.cycleLongest - 11) {
+                    } else if (day >= this.cycleShortest - luteallength - 4
+                            && day <= this.cycleLongest - luteallength + 3) {
                         // Fertile days
                         type = DayEntry.FERTILITY_PREDICTED;
                     } else {
@@ -420,8 +426,8 @@ public class PeriodicalDatabase {
                     } else if (day == ovulationday) {
                         // Day of ovulation
                         type = (cycles == 0 ? DayEntry.OVULATION_PREDICTED : DayEntry.OVULATION_FUTURE);
-                    } else if (day >= this.cycleShortest - 18
-                            && day <= this.cycleLongest - 11) {
+                    } else if (day >= this.cycleShortest - luteallength - 4
+                            && day <= this.cycleLongest - luteallength + 3) {
                         // Fertile days
                         type = (cycles == 0 ? DayEntry.FERTILITY_PREDICTED : DayEntry.FERTILITY_FUTURE);
                     } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,9 @@
     <string name="calendaraction_cancel">No</string>
     <string name="options_title">Preferences</string>
     <string name="pref_periodlength">Default length of period (days)</string>
+    <string name="pref_luteallength">Luteal phase length (days)</string>
     <string name="invalid_period_length">The default period length must be between 1 and 14!</string>
+    <string name="invalid_luteal_length">The luteal length must be at least 1!</string>
     <string name="pref_startofweek">Start of the week</string>
     <string-array name="list_startofweek">
         <item>Sunday</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -5,6 +5,11 @@
             android:defaultValue="4"
             android:key="period_length"
             android:inputType="number" />
+    <EditTextPreference
+            android:title="@string/pref_luteallength"
+            android:defaultValue="14"
+            android:key="luteal_length"
+            android:inputType="number" />
     <ListPreference
             android:title="@string/pref_startofweek"
             android:defaultValue="0"


### PR DESCRIPTION
Luteal phase (the number of days between ovulation and the start of the period) tends to be very predictable, once you know it, but varies from woman to woman. Right now the luteal phase is hard-coded at 14 days; this PR allows the user to specify it individually