### PR TITLE
Fixed problem that it was not possible to open empty day other than today

### DIFF
--- a/app/src/main/java/de/arnowelzel/android/periodical/PeriodicalDatabase.java
+++ b/app/src/main/java/de/arnowelzel/android/periodical/PeriodicalDatabase.java
@@ -862,6 +862,10 @@ class PeriodicalDatabase {
 
         if(entry == null) {
             entry = new DayEntry();
+
+            // Set chosen date
+            GregorianCalendar date = new GregorianCalendar(year, month - 1, day);
+            entry.date.setTime(date.getTime());
         }
 
         String statementNotes = format(


### PR DESCRIPTION
Problem: when opening details for any date that has not any details yet the app was opening today's date.
Expected behavior: open the date that was clicked.
Solution: when selected date doesn't have any details yet, set entry's date to selected date not current date.