### PR TITLE
Correction of incorrect grammatical case in the word month

### DIFF
--- a/app/src/main/java/de/arnowelzel/android/periodical/MainActivityApp.java
+++ b/app/src/main/java/de/arnowelzel/android/periodical/MainActivityApp.java
@@ -50,7 +50,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.ViewFlipper;
 
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 
@@ -523,9 +523,10 @@ public class MainActivityApp extends AppCompatActivity
 
         // Output current year/month
         TextView displayDate = findViewById(R.id.displaydate);
-        @SuppressLint("SimpleDateFormat") SimpleDateFormat dateFormat = new SimpleDateFormat("MMMM yyyy");
-        displayDate.setText(String.format("%s", dateFormat.format(cal.getTime())));
-        displayDate.setContentDescription(String.format("%s", dateFormat.format(cal.getTime())));
+        DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("LLLL yyyy");
+        String formatted = dateFormat.format(cal.toZonedDateTime());
+        displayDate.setText(String.format("%s", formatted));
+        displayDate.setContentDescription(String.format("%s", formatted));
 
         // Calculate first week day of month
         firstDayOfWeek = cal.get(Calendar.DAY_OF_WEEK);


### PR DESCRIPTION
Correction of incorrect grammatical case in the word month in the calendar:

For example, in Czech it is not `června 2024` but `červen 2024`.